### PR TITLE
Fix when run as subcontent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-jsdoc": "^50.6.0",
         "eslint-plugin-react": "^7.37.2",
         "mini-css-extract-plugin": "^2.9.2",
-        "sass": "^1.81.0",
+        "sass": "^1.81.1",
         "sass-loader": "^16.0.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4"
@@ -6412,9 +6412,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
-      "integrity": "sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==",
+      "version": "1.81.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.1.tgz",
+      "integrity": "sha512-VNLgf4FC5yFyKwAumAAwwNh8X4SevlVREq3Y8aDZIkm0lI/zO1feycMXQ4hn+eB6FVhRbleSQ1Yb/q8juSldTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,10 @@
         "css-loader": "^7.1.2",
         "eslint": "^8.56.0",
         "eslint-config-ndla-h5p": "github:NDLANO/eslint-config-ndla-h5p",
-        "eslint-plugin-jsdoc": "^50.4.3",
+        "eslint-plugin-jsdoc": "^50.6.0",
         "eslint-plugin-react": "^7.37.2",
         "mini-css-extract-plugin": "^2.9.2",
-        "sass": "^1.80.6",
+        "sass": "^1.81.0",
         "sass-loader": "^16.0.3",
         "webpack": "^5.96.1",
         "webpack-cli": "^5.1.4"
@@ -3158,10 +3158,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3775,9 +3776,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "50.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.4.3.tgz",
-      "integrity": "sha512-uWtwFxGRv6B8sU63HZM5dAGDhgsatb+LONwmILZJhdRALLOkCX2HFZhdL/Kw2ls8SQMAVEfK+LmnEfxInRN8HA==",
+      "version": "50.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-50.6.0.tgz",
+      "integrity": "sha512-tCNp4fR79Le3dYTPB0dKEv7yFyvGkUCa+Z3yuTrrNGGOxBlXo9Pn0PEgroOZikUQOGjxoGMVKNjrOHcYEdfszg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -4700,10 +4701,11 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
-      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
-      "dev": true
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -6410,14 +6412,14 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.80.6",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.80.6.tgz",
-      "integrity": "sha512-ccZgdHNiBF1NHBsWvacvT5rju3y1d/Eu+8Ex6c21nHp2lZGLBEtuwc415QfiI1PJa1TpCo3iXwwSRjRpn2Ckjg==",
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
+      "integrity": "sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
-        "immutable": "^4.0.0",
+        "immutable": "^5.0.2",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "css-loader": "^7.1.2",
     "eslint": "^8.56.0",
     "eslint-config-ndla-h5p": "github:NDLANO/eslint-config-ndla-h5p",
-    "eslint-plugin-jsdoc": "^50.4.3",
+    "eslint-plugin-jsdoc": "^50.6.0",
     "eslint-plugin-react": "^7.37.2",
     "mini-css-extract-plugin": "^2.9.2",
-    "sass": "^1.80.6",
+    "sass": "^1.81.0",
     "sass-loader": "^16.0.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-plugin-jsdoc": "^50.6.0",
     "eslint-plugin-react": "^7.37.2",
     "mini-css-extract-plugin": "^2.9.2",
-    "sass": "^1.81.0",
+    "sass": "^1.81.1",
     "sass-loader": "^16.0.3",
     "webpack": "^5.96.1",
     "webpack-cli": "^5.1.4"

--- a/src/scripts/components/Scene/Scene.js
+++ b/src/scripts/components/Scene/Scene.js
@@ -75,9 +75,23 @@ export default class Scene extends React.Component {
       return;
     }
 
+    let params = {};
+    if (this.context.parent instanceof H5PEditor.Form) {
+      // Content is run standalone
+      params = this.context.parent.params;
+    }
+    else if (this.context.parent instanceof H5PEditor.Library) {
+      // Content is run as subcontent
+      params = this.context.parent.params.params;
+    }
+    else {
+      // Should never happen
+      console.error('Virtual Tour: Parent is not main form or library');
+    }
+
     this.preview = initializeThreeSixtyPreview(
       this.previewRef.current,
-      this.context.parent.params,
+      params,
       {
         edit: this.context.t('edit'),
         delete: this.context.t('delete'),


### PR DESCRIPTION
When merged in, will stop making assumptions about what the parent library is to retrieve parameters.

When using Escape Room as subcontent, the editor will crash at a certain point. The cause is a bug in the original Virtual Tour implementation that implicitly assumes that the parent instance is the main editor form which does not provide params the way that an editor library widget does - the latter is what we deal with when the content is run as subcontent.